### PR TITLE
adds units to hitbox radius attribute

### DIFF
--- a/css_cooarchi.css
+++ b/css_cooarchi.css
@@ -157,7 +157,7 @@ body svg{
 	fill: transparent;
     background-color: transparent;
     stroke-width: 2;
-    r: 30;
+    r: 30px;
 	/* filter: drop-shadow( 0px 0px 10px rgba(255, 255, 255, .3));*/
     }
 	
@@ -167,7 +167,7 @@ body svg{
 	fill: transparent;
     background-color: transparent;
     stroke-width: 2;
-    r: 30;
+    r: 30px;
 	/* filter: drop-shadow( 0px 0px 10px rgba(255, 255, 255, .3));*/
     }
 


### PR DESCRIPTION
This pull request makes Nodes selectable/moveable on Firefox.
Non-Null values for `r` need to have a unit to be valid in Firefox.